### PR TITLE
feat: support --verbose

### DIFF
--- a/packages/flutterw/lib/src/hook.dart
+++ b/packages/flutterw/lib/src/hook.dart
@@ -1,6 +1,9 @@
 import 'dart:io';
 
 import 'package:cli_hook/cli_hook.dart';
+import 'package:cli_util/cli_logging.dart';
+
+import 'logger.dart';
 
 /// Script needs args can add this placeholder.
 const _kArgsPlaceholder = '<args>';
@@ -14,30 +17,50 @@ class ScriptHook extends Hook {
 
   final List<String> scripts;
 
+  final Logger logger;
+
   ScriptHook({
     required this.name,
     required List<String> scripts,
+    required this.logger,
   }) : scripts = scripts.map((e) => e.trim()).toList();
 
   @override
-  Future<void> run(Iterable<String> args) async {
-    stderr.writeln('Running $name script');
+  Future<void> run(List<String> args) async {
+    logger.name(name);
+
+    /// Assume -v,--verbose is mostly placed end of args,
+    /// search it from end to start
+    var verboseIndex = -1;
+    for (var i = args.length - 1; i >= 0; i--) {
+      if (args[i] == '--verbose' || args[i] == '-v') {
+        verboseIndex = i;
+        break;
+      }
+    }
     for (String script in scripts) {
-      await execScript(script, args);
+      await execScript(script, args, verbose: verboseIndex != -1);
     }
   }
 
   /// Replace [_kArgsPlaceholder] in script to args,
   /// then execute this script.
-  Future<void> execScript(String script, Iterable<String> args) async {
+  Future<void> execScript(String script, List<String> args,
+      {bool verbose = false}) async {
     final segments = script.split(RegExp(r'\s+'));
 
-    /// Assume <args> is placed end of this script,
+    /// Assume <args> is mostly placed end of script,
     /// search it from end to start
     var argsIndex = -1;
+    var verboseIndex = -1;
     for (var i = segments.length - 1; i >= 0; i--) {
       if (segments[i] == _kArgsPlaceholder) {
         argsIndex = i;
+      }
+      if (segments[i] == '--verbose' || segments[i] == '-v') {
+        verboseIndex = i;
+      }
+      if (argsIndex != -1 && verboseIndex != -1) {
         break;
       }
     }
@@ -46,17 +69,22 @@ class ScriptHook extends Hook {
     if (argsIndex != -1) {
       segments.replaceRange(argsIndex, argsIndex + 1, args);
     }
+    final isVerbose = verbose || verboseIndex != -1;
+    logger.script(segments.join(' '), isVerbose);
     final process = await Process.start(
       segments.removeAt(0),
       segments,
+      mode: isVerbose ? ProcessStartMode.inheritStdio : ProcessStartMode.normal,
     );
     final code = await process.exitCode;
+    logger.result(code == 0);
     if (code != 0) {
       exit(code);
     }
   }
 
-  static Map<String, ScriptHook> transform(Map<String, dynamic> scripts) {
+  static Map<String, ScriptHook> transform(
+      Map<String, dynamic> scripts, Logger logger) {
     if (scripts.isEmpty) {
       return {};
     }
@@ -66,6 +94,7 @@ class ScriptHook extends Hook {
             key,
             ScriptHook(
               name: key,
+              logger: logger,
               scripts: value.cast(),
             ));
       } else {
@@ -73,6 +102,7 @@ class ScriptHook extends Hook {
             key,
             ScriptHook(
               name: key,
+              logger: logger,
               scripts: (value as String).split('&&'),
             ));
       }

--- a/packages/flutterw/lib/src/logger.dart
+++ b/packages/flutterw/lib/src/logger.dart
@@ -1,0 +1,23 @@
+import 'package:cli_util/cli_logging.dart';
+
+extension FlutterwLogging on Logger {
+  void name(String name) {
+    stderr(ansi.emphasized('${ansi.yellow}$name${ansi.none}'));
+  }
+
+  void script(String script, bool isVerbose) {
+    if (isVerbose) {
+      stderr(ansi.emphasized('  └> ${ansi.cyan}$script${ansi.none}'));
+    } else {
+      progress(ansi.emphasized('  └> ${ansi.cyan}$script${ansi.none}'));
+    }
+  }
+
+  void result(bool success) {
+    if (success) {
+      stderr(ansi.emphasized('    └> ${ansi.green}SUCCESS${ansi.none}'));
+    } else {
+      stderr(ansi.emphasized('    └> ${ansi.red}FAILED${ansi.none}'));
+    }
+  }
+}

--- a/packages/flutterw/lib/src/runner.dart
+++ b/packages/flutterw/lib/src/runner.dart
@@ -19,20 +19,24 @@ import 'version.g.dart';
 /// ```
 class FlutterwRunner extends CommandRunner with WrapperRunner, HookRunner {
   FlutterwRunner({
-    Map<String, dynamic> scripts = const {},
+    this.scripts = const {},
     Logger? logger,
   })  : logger = logger ?? Logger.standard(),
-        hooks = ScriptHook.transform(scripts),
         super('flutterw',
             'flutterw wraps flutter with scripts and command hooks support');
 
+  /// Scripts map.
+  /// Each can be a single string or a list of strings
+  final Map<String, dynamic> scripts;
+
+  /// Flutterw Logger
   final Logger logger;
 
   @override
   String get originExecutableName => 'flutter';
 
   @override
-  final Map<String, Hook> hooks;
+  Map<String, Hook> get hooks => ScriptHook.transform(scripts, logger);
 
   @override
   String? get usageFooter =>

--- a/packages/flutterw/pubspec.yaml
+++ b/packages/flutterw/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   args: ^2.3.1
   path: ^1.8.1
   yaml: ^3.1.0
-  cli_hook: ^0.2.0
+  cli_hook: ^0.3.0
   cli_util: ^0.3.5
   cli_wrapper: ^0.5.0
 dev_dependencies:


### PR DESCRIPTION
This is a feature requested by #15 

> Two scenes:
> - [x] `--verbose` passed to `flutterw`
> - [x] `--verbose` in script

 https://github.com/hyiso/flutterw/issues/15#issuecomment-1413801910

Now, passing `-v,--verbose` to `flutterw` or script itself contains `-v,--verbose` will lead to verbose logging